### PR TITLE
Fix indenting of strings after opening paren

### DIFF
--- a/indent/python.vim
+++ b/indent/python.vim
@@ -250,7 +250,7 @@ function! s:is_python_string(lnum, ...)
     let line = getline(a:lnum)
     let linelen = len(line)
     if linelen < 1
-      return 0
+      let linelen = 1
     endif
     let cols = a:0 ? type(a:1) != type([]) ? [a:1] : a:1 : range(1, linelen)
     for cnum in cols
@@ -269,8 +269,18 @@ function! GetPythonPEPIndent(lnum)
         return 0
     endif
 
-    if (len(getline(a:lnum)) == 0 || s:is_python_string(a:lnum))
-          \ && s:is_python_string(a:lnum-1, len(getline(a:lnum-1)))
+    " Multilinestrings: continous, docstring or starting.
+    if s:is_python_string(a:lnum)
+        if s:is_python_string(a:lnum-1)
+            " Previous line is (completely) a string.
+            return s:indent_like_previous_line(a:lnum)
+        endif
+
+        if match(getline(a:lnum-1), '^\s*"""') != -1
+            " docstring.
+            return s:indent_like_previous_line(a:lnum)
+        endif
+
         return 0
     endif
 

--- a/indent/python.vim
+++ b/indent/python.vim
@@ -254,8 +254,8 @@ function! s:is_python_string(lnum, ...)
     endif
     let cols = a:0 ? type(a:1) != type([]) ? [a:1] : a:1 : range(1, linelen)
     for cnum in cols
-        if index(map(synstack(a:lnum, cnum),
-                    \ 'synIDattr(v:val,"name")'), 'pythonString') == -1
+        if match(map(synstack(a:lnum, cnum),
+                    \ 'synIDattr(v:val,"name")'), 'python\S*String') == -1
             return 0
         end
     endfor

--- a/indent/python.vim
+++ b/indent/python.vim
@@ -276,12 +276,15 @@ function! GetPythonPEPIndent(lnum)
             return s:indent_like_previous_line(a:lnum)
         endif
 
-        if match(getline(a:lnum-1), '^\s*"""') != -1
+        if match(getline(a:lnum-1), '^\s*\%("""\|''''''\)') != -1
             " docstring.
             return s:indent_like_previous_line(a:lnum)
         endif
 
-        return 0
+        if s:is_python_string(a:lnum-1, len(getline(a:lnum-1)))
+            " String started in previous line.
+            return 0
+        endif
     endif
 
     " Parens: If we can find an open parenthesis/bracket/brace, line up with it.

--- a/indent/python.vim
+++ b/indent/python.vim
@@ -245,10 +245,31 @@ function! s:indent_like_previous_line(lnum)
     return base
 endfunction
 
+" Is the syntax at lnum (and optionally cnum) a python string?
+function! s:is_python_string(lnum, ...)
+    let line = getline(a:lnum)
+    let linelen = len(line)
+    if linelen < 1
+      return 0
+    endif
+    let cols = a:0 ? type(a:1) != type([]) ? [a:1] : a:1 : range(1, linelen)
+    for cnum in cols
+        if index(map(synstack(a:lnum, cnum),
+                    \ 'synIDattr(v:val,"name")'), 'pythonString') == -1
+            return 0
+        end
+    endfor
+    return 1
+endfunction
+
 function! GetPythonPEPIndent(lnum)
 
     " First line has indent 0
     if a:lnum == 1
+        return 0
+    endif
+
+    if s:is_python_string(a:lnum) && s:is_python_string(a:lnum-1, len(getline(a:lnum-1)))
         return 0
     endif
 

--- a/indent/python.vim
+++ b/indent/python.vim
@@ -269,7 +269,8 @@ function! GetPythonPEPIndent(lnum)
         return 0
     endif
 
-    if s:is_python_string(a:lnum) && s:is_python_string(a:lnum-1, len(getline(a:lnum-1)))
+    if (len(getline(a:lnum)) == 0 || s:is_python_string(a:lnum))
+          \ && s:is_python_string(a:lnum-1, len(getline(a:lnum-1)))
         return 0
     endif
 

--- a/spec/indent/indent_spec.rb
+++ b/spec/indent/indent_spec.rb
@@ -181,6 +181,16 @@ shared_examples_for "vim" do
     end
   end
 
+  describe "when after a docstring" do
+    before { vim.feedkeys 'i    """' }
+
+    it "it does indent the next line" do
+      vim.feedkeys '\<CR>'
+      proposed_indent.should == 4
+      indent.should == 4
+    end
+  end
+
   describe "when using simple control structures" do
       it "indents shiftwidth spaces" do
           vim.feedkeys 'iwhile True:\<CR>pass'

--- a/spec/indent/indent_spec.rb
+++ b/spec/indent/indent_spec.rb
@@ -129,6 +129,22 @@ shared_examples_for "vim" do
     end
   end
 
+  describe "when after an '(' that is followed by an unfinished string" do
+    before { vim.feedkeys 'itest("""' }
+
+    it "it indents the next line" do
+      vim.feedkeys '\<CR>'
+      proposed_indent.should == 5
+      indent.should == 5
+    end
+
+    it "with contents it indents the next line" do
+      vim.feedkeys 'string_contents\<CR>'
+      proposed_indent.should == 5
+      indent.should == 5
+    end
+  end
+
   describe "when using simple control structures" do
       it "indents shiftwidth spaces" do
           vim.feedkeys 'iwhile True:\<CR>pass'

--- a/spec/indent/indent_spec.rb
+++ b/spec/indent/indent_spec.rb
@@ -132,16 +132,52 @@ shared_examples_for "vim" do
   describe "when after an '(' that is followed by an unfinished string" do
     before { vim.feedkeys 'itest("""' }
 
-    it "it indents the next line" do
+    it "it does not indent the next line" do
       vim.feedkeys '\<CR>'
-      proposed_indent.should == 5
-      indent.should == 5
+      proposed_indent.should == 0
+      indent.should == 0
     end
 
-    it "with contents it indents the next line" do
+    it "with contents it does not indent the next line" do
       vim.feedkeys 'string_contents\<CR>'
-      proposed_indent.should == 5
-      indent.should == 5
+      proposed_indent.should == 0
+      indent.should == 0
+    end
+  end
+
+  describe "when after assigning an unfinished string" do
+    before { vim.feedkeys 'itest = """' }
+
+    it "it does not indent the next line" do
+      vim.feedkeys '\<CR>'
+      proposed_indent.should == 0
+      indent.should == 0
+    end
+  end
+
+  describe "when after assigning an unfinished string" do
+    before { vim.feedkeys 'i    test = """' }
+
+    it "it does not indent the next line" do
+      vim.feedkeys '\<CR>'
+      proposed_indent.should == 0
+      indent.should == 0
+    end
+  end
+
+  describe "when after assigning a finished string" do
+    before { vim.feedkeys 'i    test = ""' }
+
+    it "it does indent the next line" do
+      vim.feedkeys '\<CR>'
+      proposed_indent.should == 4
+      indent.should == 4
+    end
+
+    it "and writing a new string, it does indent the next line" do
+      vim.feedkeys '\<CR>""'
+      proposed_indent.should == 4
+      indent.should == 4
     end
   end
 


### PR DESCRIPTION
Fixes https://github.com/hynek/vim-python-pep8-indent/issues/36

First attempt: c462de6