### PR TITLE
Fix comment for s:skip_search usage

### DIFF
--- a/indent/python.vim
+++ b/indent/python.vim
@@ -83,7 +83,7 @@ function! s:find_opening_paren(...)
 
     let stopline = max([0, line('.') - s:maxoff])
 
-    " Return if cursor is in a comment or string
+    " Return if cursor is in a comment.
     exe 'if' s:skip_search '| return [0, 0] | endif'
 
     let positions = []


### PR DESCRIPTION
This was overseen in 47ab0458.