### PR TITLE
Handle jedi-vim call signatures when looking for colon in prev line

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,5 @@ before_script:
     - "export DISPLAY=:99.0"
     - "sh -e /etc/init.d/xvfb start"
     - "bundle install"
+    - "vim --version"
 script: bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
-gem "vimrunner", "0.3.0"
+gem "vimrunner", "0.3.1"
 gem "rspec"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,8 +2,13 @@ require 'vimrunner'
 require 'vimrunner/rspec'
 
 Vimrunner::RSpec.configure do |config|
+  # Use a single Vim instance for the test suite. Set to false to use an
+  # instance per test (slower, but can be easier to manage).
   # FIXME: reuse_server = true seems to hang after a certain number of test cases
-  config.reuse_server = false
+  #  - Travis CI hangs after 15 successful tests.
+  #  - Locally it may hang also, with Vim and Xorg using 100% CPU.
+  # Therefore default to false in both cases.
+  config.reuse_server = ENV['CI'] ? false : false
 
   config.start_vim do
     vim = Vimrunner.start


### PR DESCRIPTION
This adds `jedi\S` to s:skip_special_chars and improves the algorithm to
find the colon in the previous line in `s:indent_like_previous_line`.

There should be a test for this probably?!
jedi-vim's syntax setup for the (partly concealed) call signature is at https://github.com/davidhalter/jedi-vim/blob/master/after/syntax/python.vim.