### PR TITLE
Add more indentation after function definition

### DIFF
--- a/indent/python.vim
+++ b/indent/python.vim
@@ -40,7 +40,7 @@ let s:block_rules = {
             \ '^\s*finally\>': ['try', 'except', 'else']
             \ }
 let s:paren_pairs = ['()', '{}', '[]']
-let s:control_statement = '^\s*\(if\|while\|with\|for\|except\)\>'
+let s:control_statement = '^\s*\(class\|def\|if\|while\|with\|for\|except\)\>'
 let s:stop_statement = '^\s*\(break\|continue\|raise\|return\|pass\)\>'
 
 " Skip strings and comments

--- a/spec/indent/indent_spec.rb
+++ b/spec/indent/indent_spec.rb
@@ -198,6 +198,20 @@ shared_examples_for "vim" do
       end
   end
 
+  describe "when using a function definition" do
+      it "indents shiftwidth spaces" do
+          vim.feedkeys 'idef long_function_name(\<CR>arg'
+          indent.should == shiftwidth * 2
+      end
+  end
+
+  describe "when using a class definition" do
+      it "indents shiftwidth spaces" do
+          vim.feedkeys 'iclass Foo(\<CR>'
+          indent.should == shiftwidth * 2
+      end
+  end
+
   describe "when writing an 'else' block" do
     it "aligns to the preceeding 'for' block" do
       vim.feedkeys 'ifor x in "abc":\<CR>pass\<CR>else:'


### PR DESCRIPTION
Fixes https://github.com/hynek/vim-python-pep8-indent/issues/30