### PR TITLE
Fix regression with colon-at-eol detection (#44)

### DIFF
--- a/indent/python.vim
+++ b/indent/python.vim
@@ -243,17 +243,16 @@ function! s:indent_like_previous_line(lnum)
     let ignore_last_char = eval(s:skip_special_chars)
 
     " Search for final colon that is not inside something to be ignored.
-    while search(':', 'bcW', lnum)
+    while 1
         let curpos = getpos(".")[2]
         if curpos == 1 | break | endif
-        if eval(s:skip_special_chars)
+        if eval(s:skip_special_chars) || text[curpos-1] =~ '\s'
             normal! h
             continue
-        endif
-        if !s:match_expr_on_line(s:skip_special_chars, lnum, curpos)
+        elseif text[curpos-1] == ':'
             return base + s:sw()
         endif
-        normal! h
+        break
     endwhile
 
     if text =~ '\\$' && !ignore_last_char

--- a/spec/indent/indent_spec.rb
+++ b/spec/indent/indent_spec.rb
@@ -153,6 +153,14 @@ shared_examples_for "vim" do
     end
   end
 
+  describe "when the previous line has a list slice" do
+    it "does not indent" do
+      vim.feedkeys 'ib = a[2:]\<CR>'
+      indent.should == 0
+      proposed_indent.should == 0
+    end
+  end
+
   describe "when after an '(' that is followed by an unfinished string" do
     before { vim.feedkeys 'itest("""' }
 


### PR DESCRIPTION
Instead of using `search` it now goes back and breaks if a char is found
that should not get skipped.

Fixes https://github.com/hynek/vim-python-pep8-indent/issues/44