### PR TITLE
spec_helper: pass in already obtained line

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,7 +38,7 @@ Vimrunner::RSpec.configure do |config|
     def proposed_indent
       line = vim.echo("line('.')")
       col = vim.echo("col('.')")
-      indent_value = vim.echo("GetPythonPEPIndent(line('.'))").to_i
+      indent_value = vim.echo("GetPythonPEPIndent(#{line})").to_i
       vim.command("call cursor(#{line}, #{col})")
       return indent_value
     end


### PR DESCRIPTION
The tests are quite slow, and I have the feeling that most comes from
the helpers, and more importantly not reusing the Vim instance (because
of the lockup issue).